### PR TITLE
Make pyperclip optional and update README accordingly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ A command-line-based program to fetch [BibTeX](https://www.bibtex.org/) entries 
 
 ## Requirements
 
-This program requires the following non built-in Python packages:
+This program requires the following third-party Python packages:
 
 - requests
-- pyperclip
+- Optional: pyperclip
 
 You can install these packages using pip:
 

--- a/get_bibtex.py
+++ b/get_bibtex.py
@@ -21,7 +21,10 @@ import json
 import sys
 import argparse
 import re
-import pyperclip
+try:
+    import pyperclip
+except ImportError:
+    pyperclip = None
 
 USAGE_EXAMPLES = f"""
 Examples:
@@ -59,8 +62,13 @@ def get_bibtex_crossref(doi, clipboard=False):
 
         # Copy the BibTeX entry to the clipboard if clipboard is True
         if clipboard:
-            pyperclip.copy(bibtex)
-            print("\nThe following BibTeX entry has been copied to the clipboard:\n\n" + bibtex)
+            if pyperclip:
+                pyperclip.copy(bibtex)
+                print("\nThe following BibTeX entry has been copied to the clipboard:\n\n" + bibtex)
+            else:
+                print("\npyperclip is not installed. Please install it using 'pip install pyperclip' to copy the BibTeX entry to the clipboard.",
+                      file=sys.stderr)
+                print("\n" + bibtex)
         else:
             print("\n" + bibtex)
 


### PR DESCRIPTION
For example, the user might prefer copying from their terminal emulator directly (tmux(1) makes it very easy to do this, for instance) after viewing the standard output.